### PR TITLE
Extension to allow specifying locations as a string

### DIFF
--- a/nginxtest/server.py
+++ b/nginxtest/server.py
@@ -25,13 +25,17 @@ http {
     listen ${port};
     ${server_options}
 
+    ${locations}
+  }
+}
+"""
+
+_TMPL_LOCATIONS_LIST = """\
     %for location in locations:
       location ${location['path']} {
         ${location['definition']}
       }
     %endfor
-  }
-}
 """
 
 _DEFAULTS = [('nginx', 'nginx'),
@@ -49,6 +53,8 @@ class NginxServer(object):
             if key not in options:
                 options[key] = val
 
+        if type(options['locations']) is list:
+            options['locations'] = Template(_TMPL_LOCATIONS_LIST).render(locations=options['locations'])
         # early rendering so we can stop on error
         self.conf_data = Template(_TMPL).render(**options)
         self.wdir = tempfile.mkdtemp()

--- a/nginxtest/server.py
+++ b/nginxtest/server.py
@@ -25,6 +25,7 @@ http {
   server {
     listen ${port};
     ${server_options}
+    rewrite_log on;
 
     ${locations}
   }

--- a/nginxtest/server.py
+++ b/nginxtest/server.py
@@ -5,7 +5,6 @@ import subprocess
 import shlex
 import time
 import sys
-import fcntl
 
 from mako.template import Template
 import requests

--- a/nginxtest/server.py
+++ b/nginxtest/server.py
@@ -5,6 +5,7 @@ import subprocess
 import shlex
 import time
 import sys
+import fcntl
 
 from mako.template import Template
 import requests
@@ -86,8 +87,7 @@ class NginxServer(object):
 
         if resp is None or resp.status_code != 200:
             self.stop()
-            sys.stdout.write(self._p.stdout.read())
-            sys.stderr.write(self._p.stderr.read())
+            self._forward_messages()
             if resp is None:
                 raise IOError('Failed to start Nginx')
             else:
@@ -100,9 +100,13 @@ class NginxServer(object):
         self._p.terminate()
         time.sleep(.2)
         try:
-            sys.stdout.write(self._p.stdout.read())
-            sys.stderr.write(self._p.stderr.read())
+            self._forward_messages()
             os.chdir(self.cwd)
             shutil.rmtree(self.wdir)
         finally:
             os.kill(self._p.pid, 9)
+
+    def _forward_messages(self):
+        sys.stdout.write(self._p.stdout.read())
+        sys.stderr.write(self._p.stderr.read())
+


### PR DESCRIPTION
This allows to use more elaborate nginx configuration files. I'm using it specifically for testing nginx configuration files with many regexes, rather than for functional testing, but I'm sure that it may be useful in other scenarios.
